### PR TITLE
Ensure NR Server Agent can monitor Docker

### DIFF
--- a/recipes/agent.rb
+++ b/recipes/agent.rb
@@ -12,3 +12,15 @@ node.set['newrelic']['license'] = data_bag_item('secrets', 'api_keys')['newrelic
 include_recipe 'newrelic'
 include_recipe 'et_monitoring::threatstack' if node['et_monitoring']['threatstack_enabled']
 include_recipe 'et_monitoring::snmpd'
+
+# Ensure New Relic can monitor Docker containers, if it is installed
+service 'newrelic-sysmond' do
+  action :nothing
+end
+
+group 'docker' do
+  members %w(docker newrelic)
+  action :modify
+  only_if { node['etc']['passwd']['docker'] }
+  notifies :restart, 'service[newrelic-sysmond]'
+end


### PR DESCRIPTION
This allows the New Relic Server Agent permission to monitor Docker containers, which will provide valuable insight into some of our Mesos-backed infra.

It won’t kick into gear until Docker is installed, which is likely to happen _after_ this recipe is first run, but I think this happening on second convergence, and restarting the NR Server Agent, is acceptable.